### PR TITLE
docTransform option + return cursor from getData

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,30 @@ Template.searchResult.helpers({
 });
 ```
 
-`.getData()` api accepts an object with options. These are the options you can pass:
+`.getData()` api accepts an object with options (and an optional argument to ask for a cursor instead of a fetched array; see example below). These are the options you can pass:
 
 * `transform` - a transform function to alter the selected search texts. See above for an example usage.
 * `sort` - an object with MongoDB sort specifiers
 * `limit` - no of objects to limit
+* `docTransform` - a transform function to transform the documents in the search result. Use this for computed values or model helpers. (see example below)
+
+
+```js
+Template.searchResult.helpers({
+  getPackages: function() {
+    return PackageSearch.getData({
+      docTransform: function(doc) {
+        return _.extend(doc, {
+          owner: function() {
+            return Meteor.users.find({_id: this.ownerId})
+          }
+        })
+      },
+      sort: {isoScore: -1}
+    }, true);
+  }
+});
+```
 
 ### Searching
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -124,8 +124,9 @@ SearchSource.prototype.getData = function(options, getCursor) {
         }
       });
     }
-    if(options.docTransform)
+    if(options.docTransform) {
       return options.docTransform(doc);
+    }
     
     return doc;
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -136,8 +136,9 @@ SearchSource.prototype.getData = function(options, getCursor) {
     transform: transform
   });
 
-  if(getCursor)
+  if(getCursor) {
     return cursor;
+  }
 
   return cursor.fetch();
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -96,7 +96,7 @@ SearchSource.prototype.search = function(query, options) {
   }
 };
 
-SearchSource.prototype.getData = function(options) {
+SearchSource.prototype.getData = function(options, getCursor) {
   options = options || {};
   var self = this;
   this._storeDep.depend();
@@ -116,23 +116,30 @@ SearchSource.prototype.getData = function(options) {
     selector = {};
   }
 
-
   function transform(doc) {
-    self.searchFields.forEach(function(field) {
-      if(self.currentQuery && doc[field]) {
-        if(options.transform) {
+    if(options.transform) {
+      self.searchFields.forEach(function(field) {
+        if(self.currentQuery && doc[field]) {
           doc[field] = options.transform(doc[field], regExp, field, self.currentQuery);
         }
-      }
-    });
+      });
+    }
+    if(options.docTransform)
+      return options.docTransform(doc);
+    
     return doc;
   }
 
-  return this.store.find(selector, {
+  var cursor = this.store.find(selector, {
     sort: options.sort,
     limit: options.limit,
     transform: transform
-  }).fetch();
+  });
+
+  if(getCursor)
+    return cursor;
+
+  return cursor.fetch();
 };
 
 SearchSource.prototype._fetch = function(source, query, options, callback) {

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
   "summary": "Reactive Data Source for Search",
-  "version": "1.2.1",
-  "git": "https://github.com/Sewdn/search-source.git",
-  "name": "sewdn:search-source"
+  "version": "1.2.0",
+  "git": "https://github.com/meteorhacks/search-source.git",
+  "name": "meteorhacks:search-source"
 });
 
 Npm.depends({

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
   "summary": "Reactive Data Source for Search",
-  "version": "1.2.0",
-  "git": "https://github.com/meteorhacks/search-source.git",
-  "name": "meteorhacks:search-source"
+  "version": "1.2.1",
+  "git": "https://github.com/Sewdn/search-source.git",
+  "name": "sewdn:search-source"
 });
 
 Npm.depends({


### PR DESCRIPTION
Add optional configuration setting (docTransform) to transform search results documents. The current transform option adds the possibility to transform the fields of the found documents, but there is now way to add document helpers (model helpers) to the documents.

Also add the ability to return a cursor (getData) instead of a hydrated array.