### PR TITLE
catching ejson parsing exception

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -176,7 +176,12 @@ SearchSource.prototype._fetchHttp = function(source, query, options, callback) {
     if(err) {
       callback(err);
     } else {
-      var response = EJSON.parse(res.content);
+      try {
+        var response = EJSON.parse(res.content);
+      } catch(e) {
+        return callback(e);
+      }
+      
       if(response.error) {
         callback(response.error);
       } else {


### PR DESCRIPTION
This prevents Uncaught exception error while parsing EJSON response that appear sometimes on mobile ios device (path sending html instead of json). 