### PR TITLE
Consider options for cached history.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,9 +18,10 @@ SearchSource = function SearchSource(source, fields, options) {
 SearchSource.prototype._loadData = function(query, options) {
   var self = this;
   var version = 0;
-  if(this._canUseHistory(query)) {
-    this._updateStore(this.history[query].data);
-    this.metaData.set(this.history[query].metadata);
+  var historyKey = query + EJSON.stringify(options);
+  if(this._canUseHistory(historyKey)) {
+    this._updateStore(this.history[historyKey].data);
+    this.metaData.set(this.history[historyKey].metadata);
     self._storeDep.changed();
   } else {
     this.status.set({loading: true});
@@ -43,7 +44,7 @@ SearchSource.prototype._loadData = function(query, options) {
       }
 
       if(self.options.keepHistory) {
-        self.history[query] = {data: data, loaded: new Date(), metadata: metadata};
+        self.history[historyKey] = {data: data, loaded: new Date(), metadata: metadata};
       }
 
       if(version > self._loadedVersion) {
@@ -60,8 +61,8 @@ SearchSource.prototype._loadData = function(query, options) {
   }
 };
 
-SearchSource.prototype._canUseHistory = function(query) {
-  var historyItem = this.history[query];
+SearchSource.prototype._canUseHistory = function(historyKey) {
+  var historyItem = this.history[historyKey];
   if(this.options.keepHistory && historyItem) {
     var diff = Date.now() - historyItem.loaded.getTime();
     return diff < this.options.keepHistory;
@@ -81,7 +82,7 @@ SearchSource.prototype._updateStore = function(data) {
 
   // Remove items in client DB that we no longer need
   var currentIdMappings  = {};
-  _.each(currentIds, function(currentId) { 
+  _.each(currentIds, function(currentId) {
     // to support Object Ids
     var str = (currentId._str)? currentId._str : currentId;
     currentIdMappings[str] = true;
@@ -138,7 +139,7 @@ SearchSource.prototype.getData = function(options, getCursor) {
     if(options.docTransform) {
       return options.docTransform(doc);
     }
-    
+
     return doc;
   }
 


### PR DESCRIPTION
I am using the options parameter to pass filter and sort parameter for the search. If combined with a limit this returns incorrect results, when the search term (query) stays the same, but the filter or sort parameters are changed, since this doesn't trigger a new search on the server. To fix this I stringify the options and add them to the query to use as history key.