### PR TITLE
Allow transforming nested fields.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -128,11 +128,27 @@ SearchSource.prototype.getData = function(options, getCursor) {
     selector = {};
   }
 
+  function pick(doc, field) {
+    if (_.isString(field)) field = field.split('.');
+    if (!_.isArray(field)) return doc[field];
+    var tmp = doc;
+    while (i = field.shift())
+      tmp = tmp[i];
+    return tmp;
+  };
+
+  function put(doc, field, value) {
+    if (_.isString(field)) field = field.split('.');
+    if (!_.isArray(field)) doc[field] = value;
+    pick(doc, _.initial(field))[_.last(field)] = value;
+  };
+
   function transform(doc) {
     if(options.transform) {
       self.searchFields.forEach(function(field) {
-        if(self.currentQuery && doc[field]) {
-          doc[field] = options.transform(doc[field], regExp, field, self.currentQuery);
+        var property = pick(doc, field);
+        if(self.currentQuery && property) {
+          put(doc, field, options.transform(property, regExp, field, self.currentQuery));
         }
       });
     }


### PR DESCRIPTION
I improved the transform function to accept nested fields separated by dots.

Example:
UserSearch = new SearchSource('users', ['profile.firstname', 'profile.lastname'], {keepHistory: 1000 * 60 * 5, localSearch: true})
